### PR TITLE
Add handling for entries which exist only in old or new CSV

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,15 +38,24 @@ impl CsvComparator {
 
     fn get_diffs(&self) -> Result<Vec<Row>> {
         let mut result = Vec::new();
-        let mut all_contracts: HashMap<String, ()> = self.old_csv.iter().map(|(k, _)| (k.clone(), ())).collect();
+        let mut all_contracts: HashMap<String, ()> =
+            self.old_csv.iter().map(|(k, _)| (k.clone(), ())).collect();
         self.new_csv.iter().for_each(|(k, _)| {
             all_contracts.insert(k.clone(), ());
         });
 
         for (contract, _) in all_contracts {
             let def = (UnoptimizedSize::default(), OptimizedSize::default());
-            let (unopt_size_old, opt_size_old) = self.old_csv.get(&contract).or(Some(&def)).expect("failed getting old_csv entry");
-            let (unopt_size_new, opt_size_new) = self.new_csv.get(&contract).or(Some(&def)).expect("failed getting new_csv entry");
+            let (unopt_size_old, opt_size_old) = self
+                .old_csv
+                .get(&contract)
+                .or(Some(&def))
+                .expect("failed getting old_csv entry");
+            let (unopt_size_new, opt_size_new) = self
+                .new_csv
+                .get(&contract)
+                .or(Some(&def))
+                .expect("failed getting new_csv entry");
             let unopt_diff = unopt_size_new - unopt_size_old;
             let opt_diff = opt_size_new - opt_size_old;
 
@@ -106,23 +115,27 @@ mod tests {
     #[test]
     fn entries_from_old_csv_must_appear_in_diff() {
         // given
-        let mut old_csv: HashMap::<String, (UnoptimizedSize, OptimizedSize)> = HashMap::new();
-        let new_csv: HashMap::<String, (UnoptimizedSize, OptimizedSize)> = HashMap::new();
-        old_csv.insert("removed_in_new_csv".to_string(), (UnoptimizedSize::default(), OptimizedSize::default()));
-        let comparator = CsvComparator {
-            old_csv,
-            new_csv,
-        };
+        let mut old_csv: HashMap<String, (UnoptimizedSize, OptimizedSize)> = HashMap::new();
+        let new_csv: HashMap<String, (UnoptimizedSize, OptimizedSize)> = HashMap::new();
+        old_csv.insert(
+            "removed_in_new_csv".to_string(),
+            (UnoptimizedSize::default(), OptimizedSize::default()),
+        );
+        let comparator = CsvComparator { old_csv, new_csv };
 
         // when
         let res = comparator.get_diffs().expect("getting diffs failed");
 
         // then
         let mut iter = res.iter();
-        assert_eq!(iter.next().expect("first diff entry must exist"), &Row { name: "removed_in_new_csv".to_string(),
-            unoptimized_size: UnoptimizedSize::default(),
-            optimized_size: OptimizedSize::default(),
-        });
+        assert_eq!(
+            iter.next().expect("first diff entry must exist"),
+            &Row {
+                name: "removed_in_new_csv".to_string(),
+                unoptimized_size: UnoptimizedSize::default(),
+                optimized_size: OptimizedSize::default(),
+            }
+        );
         assert_eq!(iter.next(), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ type Result<T> = std::result::Result<T, Box<dyn Error>>;
 type OptimizedSize = f32;
 type UnoptimizedSize = f32;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 struct Row {
     name: String,
     unoptimized_size: UnoptimizedSize,
@@ -36,24 +36,29 @@ impl CsvComparator {
         read_csv(&mut self.new_csv, file)
     }
 
-    fn get_diffs(&mut self) -> Result<()> {
-        let mut wtr = csv::WriterBuilder::new()
-            .has_headers(false)
-            .from_writer(io::stdout());
+    fn get_diffs(&self) -> Result<Vec<Row>> {
+        let mut result = Vec::new();
+        let mut all_contracts: HashMap<String, ()> = self.old_csv.iter().map(|(k, _)| (k.clone(), ())).collect();
+        self.new_csv.iter().for_each(|(k, _)| {
+            all_contracts.insert(k.clone(), ());
+        });
 
-        for (contract, (unopt_size_old, opt_size_old)) in &self.old_csv {
-            let (unopt_size_new, opt_size_new) = self.new_csv.get(contract).unwrap();
+        for (contract, _) in all_contracts {
+            let def = (UnoptimizedSize::default(), OptimizedSize::default());
+            let (unopt_size_old, opt_size_old) = self.old_csv.get(&contract).or(Some(&def)).expect("failed getting old_csv entry");
+            let (unopt_size_new, opt_size_new) = self.new_csv.get(&contract).or(Some(&def)).expect("failed getting new_csv entry");
             let unopt_diff = unopt_size_new - unopt_size_old;
             let opt_diff = opt_size_new - opt_size_old;
 
-            wtr.serialize(Row {
+            let row = Row {
                 name: contract.to_string(),
                 unoptimized_size: unopt_diff,
                 optimized_size: opt_diff,
-            })?;
+            };
+            result.push(row);
         }
 
-        Ok(())
+        Ok(result)
     }
 }
 
@@ -82,7 +87,42 @@ fn main() -> Result<()> {
     let mut comparator = CsvComparator::new();
     comparator.write_old(old)?;
     comparator.write_new(new)?;
-    comparator.get_diffs()?;
+
+    let mut wtr = csv::WriterBuilder::new()
+        .has_headers(false)
+        .from_writer(io::stdout());
+
+    for row in comparator.get_diffs()? {
+        wtr.serialize(row)?;
+    }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entries_from_old_csv_must_appear_in_diff() {
+        // given
+        let mut old_csv: HashMap::<String, (UnoptimizedSize, OptimizedSize)> = HashMap::new();
+        let new_csv: HashMap::<String, (UnoptimizedSize, OptimizedSize)> = HashMap::new();
+        old_csv.insert("removed_in_new_csv".to_string(), (UnoptimizedSize::default(), OptimizedSize::default()));
+        let comparator = CsvComparator {
+            old_csv,
+            new_csv,
+        };
+
+        // when
+        let res = comparator.get_diffs().expect("getting diffs failed");
+
+        // then
+        let mut iter = res.iter();
+        assert_eq!(iter.next().expect("first diff entry must exist"), &Row { name: "removed_in_new_csv".to_string(),
+            unoptimized_size: UnoptimizedSize::default(),
+            optimized_size: OptimizedSize::default(),
+        });
+        assert_eq!(iter.next(), None);
+    }
 }


### PR DESCRIPTION
This adds handling for those cases:
* if an entry is only existent in the old csv
* if an entry is only existent in the new csv

I found this while wondering why our regression bot didn't properly post the `proxy` results in https://github.com/paritytech/ink/pull/1020. This is the job: https://gitlab.parity.io/parity/ink-waterfall/-/jobs/1241718.